### PR TITLE
Added Mistral API initial integration with streaming and Non-Streaming

### DIFF
--- a/examples/mistral.py
+++ b/examples/mistral.py
@@ -1,0 +1,25 @@
+from wrapper.core import Wrapper
+
+# Initialize Mistral client
+mistral_client = Wrapper("mistral")
+
+# List available models
+models = mistral_client.available_models_api("mistral")
+print("Available models:", models)
+
+# Generate text (non-streaming)
+response = mistral_client.generate(
+    model="mistral-tiny",  # Replace with a valid model from the list
+    prompt="Hello, how are you?",
+    system="You are a helpful assistant."
+)
+print("\nNon-streaming response:\n", response)
+
+# Generate text (streaming)
+print("\nStreaming response:")
+for chunk in mistral_client.generate(
+    model="mistral-tiny",  # Replace with a valid model from the list
+    prompt="Tell me a joke.",
+    stream=True
+):
+    print(chunk, end="", flush=True)

--- a/wrapper/core.py
+++ b/wrapper/core.py
@@ -3,6 +3,7 @@ from .providers.openai_provider import OpenAIProvider
 from .providers.ollama_provider import OllamaProvider
 from .providers.groq_provider import GroqProvider
 from .providers.bedrock_provider import BedrockProvider
+from .providers.mistral_provider import MistralProvider
 from collections import defaultdict
 from .utils import ColorLogger
 from .config import *
@@ -23,7 +24,8 @@ class Wrapper:
             self.impl = GroqProvider(**kwargs)
         elif provider == "bedrock":
             self.impl = BedrockProvider(**kwargs)
-
+        elif provider == "mistral":
+            self.impl = MistralProvider(**kwargs)
         else:
             raise ValueError(f"Provider {provider} not supported yet")
         
@@ -130,6 +132,12 @@ class Wrapper:
             for i, m in enumerate(models, 1):
                 log.info(f"   {i:2d}. {m['modelId']} — {m['modelName']} ({m['provider']})")
             return models
-        
+        elif provider == "mistral":
+            instance = MistralProvider(**kwargs)
+            models = instance.list_models().get("data", [])
+            log.info("\n Mistral Models:\n")
+            for i, m in enumerate(models, 1):
+                log.info(f"   {i:2d}. {m.get('id', m)}")
+            return models
         log.warning(f"No wrapper available for provider '{provider}'.")
         return []

--- a/wrapper/providers/mistral_provider.py
+++ b/wrapper/providers/mistral_provider.py
@@ -1,0 +1,46 @@
+from wrapper.utils import get_or_request_key, ColorLogger
+from wrapper.base import BaseProvider
+import requests
+from typing import Generator, Optional, Dict, Any
+
+class MistralProvider(BaseProvider):
+    def __init__(self, config: Optional[Dict[str, Any]] = None):
+        super().__init__(config)
+        self.logger = ColorLogger("MistralProvider")
+        self.api_key = get_or_request_key("MISTRAL_API_KEY", config)
+        self.base_url = config.get("base_url", "https://api.mistral.ai/v1") if config else "https://api.mistral.ai/v1"
+        self.headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json"
+        }
+
+    def list_models(self) -> Dict[str, Any]:
+        url = f"{self.base_url}/models"
+        self.logger.info(f"Listing models from {url}")
+        response = requests.get(url, headers=self.headers)
+        response.raise_for_status()
+        return response.json()
+
+    def generate(self, prompt: str, model: str, stream: bool = False, **kwargs) -> Any:
+        url = f"{self.base_url}/chat/completions"
+        payload = {
+            "model": model,
+            "messages": [{"role": "user", "content": prompt}],
+            **kwargs
+        }
+        if stream:
+            payload["stream"] = True
+            self.logger.info(f"Streaming completion from {url} for model {model}")
+            return self._streaming_request(url, payload)
+        else:
+            self.logger.info(f"Non-streaming completion from {url} for model {model}")
+            response = requests.post(url, headers=self.headers, json=payload)
+            response.raise_for_status()
+            return response.json()
+
+    def _streaming_request(self, url: str, payload: dict) -> Generator[str, None, None]:
+        with requests.post(url, headers=self.headers, json=payload, stream=True) as response:
+            response.raise_for_status()
+            for line in response.iter_lines():
+                if line:
+                    yield line.decode("utf-8")


### PR DESCRIPTION
This pull request adds support for the Mistral AI provider to the wrapper library, allowing users to list available Mistral models and generate text completions (both streaming and non-streaming). The main changes include integrating the new provider, updating the core wrapper logic, and providing an example usage script.

**Mistral provider integration:**

* Added a new `MistralProvider` class in `wrapper/providers/mistral_provider.py` to handle authentication, list available models, and generate text completions (both streaming and non-streaming) using the Mistral API.
* Registered `MistralProvider` in the `Wrapper` class in `wrapper/core.py`, enabling it as a selectable provider. [[1]](diffhunk://#diff-39b64ee5d1d5e2994ccd4af2c9f05fbe009445221dae5cd461ea023d3459b126R6) [[2]](diffhunk://#diff-39b64ee5d1d5e2994ccd4af2c9f05fbe009445221dae5cd461ea023d3459b126L26-R28)

**Core wrapper updates:**

* Updated the `available_models_api` method in `wrapper/core.py` to support listing models from the Mistral provider and logging the results.

**Example usage:**

* Added a new example script `examples/mistral.py` demonstrating how to initialize the wrapper with the Mistral provider, list models, and generate both non-streaming and streaming completions.